### PR TITLE
feat: add new field level custom Serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The packages are published to the GitHub maven repository. Make sure to add it t
 <dependency>
   <groupId>com.redhat.ecosystemappeng</groupId>
   <artifactId>exhort-api</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.0.3-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -36,5 +36,5 @@ echo "@RHEcosystemAppEng:registry=https://npm.pkg.github.com" >> .npmrc
 Then, add it to your project as follows:
 
 ```bash
-npm install @RHEcosystemAppEng/exhort-javascript-api@1.0.2-SNAPSHOT
+npm install @RHEcosystemAppEng/exhort-javascript-api@1.0.3-SNAPSHOT
 ```

--- a/api/v4/openapi.yaml
+++ b/api/v4/openapi.yaml
@@ -236,8 +236,10 @@ components:
             $ref: '#/components/schemas/TransitiveDependencyReport'
         recommendation:
           description: Trusted Content recommendation that is not related to any security vulnerability
+          x-field-extra-annotation: '@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.redhat.exhort.api.serialization.PackageRefSerializer.class)'
           allOf:
             - $ref: '#/components/schemas/PackageRef'
+
         highestVulnerability:
           description: Highest vulnerability found for this dependency
           $ref: '#/components/schemas/Issue'

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.redhat.ecosystemappeng</groupId>
   <artifactId>exhort-api-spec</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.0.3-SNAPSHOT</version>
   <name>Exhort Java API</name>
   <description>Red Hat Trusted Profile Analizer :: Exhort :: Java API</description>
   <url>https://github.com/RHEcosystemAppEng/exhort-api-spec</url>

--- a/src/main/java/com/redhat/exhort/api/serialization/PackageRefSerializer.java
+++ b/src/main/java/com/redhat/exhort/api/serialization/PackageRefSerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.exhort.api.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.github.packageurl.PackageURL;
+import com.redhat.exhort.api.PackageRef;
+
+import java.io.IOException;
+
+public class PackageRefSerializer extends StdSerializer<PackageRef> {
+
+  public PackageRefSerializer() {
+    this(null);
+  }
+
+  public PackageRefSerializer(Class<PackageRef> c) {
+    super(c);
+  }
+
+  @Override
+  public void serialize(PackageRef value, JsonGenerator gen, SerializerProvider provider)
+      throws IOException {
+    gen.writeString(value.purl().toString());
+  }
+}


### PR DESCRIPTION
for DependencyReport' PackageRef' recommendation field, in order to serialize it to JSON with full purl ( not only coordinates) -  as we need also `qualifiers` part of the purl , which contains key=value of repository_url=https://maven.repository.redhat.com/ga/&type=jar.