### PR TITLE
feat!:rename package to ref

### DIFF
--- a/api/v4/openapi.yaml
+++ b/api/v4/openapi.yaml
@@ -295,7 +295,7 @@ components:
         trustedContent:
           type: object
           properties:
-            package:
+            ref:
               $ref: '#/components/schemas/PackageRef'
             status:
               type: string


### PR DESCRIPTION
Renamed `package` to `ref` for `remediation.trustedContent` to avoid using reserved language names that end up being prefixed with `_`