### PR TITLE
fix: bump packageUrl dep to fix idempotency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.5.0</quarkus.platform.version>
-    <packageurl.version>1.4.1</packageurl.version>
+    <packageurl.version>1.5.0</packageurl.version>
     <!-- Plugins -->
     <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>

--- a/src/main/java/com/redhat/exhort/api/PackageRef.java
+++ b/src/main/java/com/redhat/exhort/api/PackageRef.java
@@ -76,10 +76,21 @@ public class PackageRef {
     return purl.getVersion();
   }
 
+  public boolean isCoordinatesEquals(PackageRef other) {
+    if(other == null) {
+      return false;
+    }
+    if(other.purl == null) {
+      return this.purl == null;
+    }
+    return this.purl.isCoordinatesEquals(other.purl);
+  }
+  
   @Override
   public int hashCode() {
     return purl.hashCode();
   }
+
 
   @Override
   public boolean equals(Object other) {

--- a/src/test/java/com/redhat/exhort/api/PackageRefTest.java
+++ b/src/test/java/com/redhat/exhort/api/PackageRefTest.java
@@ -20,6 +20,7 @@ package com.redhat.exhort.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,5 +51,19 @@ public class PackageRefTest {
 
     ref = new PackageRef("pkg:golang/go.opencensus.io@v0.21.0");
     assertEquals("v0.21.0", ref.version());
+  }
+
+  @Test
+  public void testCoordinatesEquals() {
+    var originalPurl = "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2.redhat-00005?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar";
+    var coordinates = "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2.redhat-00005";
+    var ref = new PackageRef(originalPurl);
+    assertEquals(originalPurl, ref.toString());
+
+    assertEquals(coordinates, ref.purl().getCoordinates());
+
+    assertEquals(originalPurl, ref.toString());
+
+    assertTrue(ref.isCoordinatesEquals(new PackageRef(coordinates)));
   }
 }


### PR DESCRIPTION
PackageURL 1.4.1 had a bug where the `getCoordinates` method was not idempotent and was changing the content of the `purl` definition itself so that a next call to `toString` will not contain the Qualifiers.

I have also added a convenience method to compare by coordinates