### PR TITLE
chore: deploy to mvn central

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -52,3 +52,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RC_VERSION: ${{ github.run_number }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/.github/workflows/maven/settings.xml
+++ b/.github/workflows/maven/settings.xml
@@ -1,0 +1,14 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <server>
+      <id>central</id>
+      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+      <password>${env.MAVEN_CENTRAL_TOKEN}</password>
+    </server>
+  </servers>
+
+</settings>

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,11 +45,13 @@ jobs:
         run: mvn -B versions:set -DremoveSnapshot -DgenerateBackupPoms=false
 
       - name: Build and Deploy
-        run: mvn -B deploy -Ppublish -Prelease
+        run: mvn -s .github/workflows/maven/settings.xml -B deploy -Ppublish -Prelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
 
       - name: Get version
         id: get_version

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The packages are published to the GitHub maven repository. Make sure to add it t
 
 ```xml
 <dependency>
-  <groupId>com.github.guacsec</groupId>
+  <groupId>io.github.guacsec</groupId>
   <artifactId>trustify-da-api-model</artifactId>
-  <version>1.0.19-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -29,5 +29,5 @@ The packages are published to the GitHub maven repository. Make sure to add it t
 Add it to your project as follows:
 
 ```bash
-npm install @guacsec/trustify-da-api-model@1.0.19-SNAPSHOT
+npm install @guacsec/trustify-da-api-model@2.0.0-SNAPSHOT
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -3,16 +3,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.github.guacsec</groupId>
-  <artifactId>trustify-da-api</artifactId>
-  <version>1.0.19-SNAPSHOT</version>
+  <groupId>io.github.guacsec</groupId>
+  <artifactId>trustify-da-api-model</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
   <name>Trustify Dependency Analytics API Spec</name>
   <description>Trustify :: Dependency Analytics :: Java API</description>
   <url>https://github.com/guacsec/trustify-da-api-spec</url>
   <inceptionYear>2023</inceptionYear>
 
   <properties>
-    <package.name>trustify-da-api-model</package.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
     <js-api>${project.build.directory}/js-api</js-api>
@@ -45,6 +44,7 @@
     <openapi-generator-maven-plugin.version>7.0.1</openapi-generator-maven-plugin.version>
     <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
     <frontend-maven-plugin.version>1.13.4</frontend-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
     <!-- Node and Yarn -->
     <node.version>v20.9.0</node.version>
     <yarn.version>v1.22.19</yarn.version>
@@ -57,6 +57,15 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <developers>
+    <developer>
+      <name>Ruben Romero Montes</name>
+      <email>rromerom@redhat.com</email>
+      <organization>Red Hat</organization>
+      <organizationUrl>https://www.redhat.com</organizationUrl>
+    </developer>
+  </developers>
 
   <issueManagement>
     <system>GitHub Issues</system>
@@ -77,10 +86,13 @@
 
   <distributionManagement>
     <repository>
-      <id>github</id>
-      <name>Guacsec Maven Packages</name>
-      <url>https://maven.pkg.github.com/guacsec/trustify-da-api-spec</url>
+      <id>central</id>
+      <name>Maven Central</name>
     </repository>
+    <snapshotRepository>
+      <id>central</id>
+      <name>Maven Central Snapshots</name>
+    </snapshotRepository>
   </distributionManagement>
 
   <dependencyManagement>
@@ -130,7 +142,6 @@
   </dependencies>
 
   <build>
-    <finalName>${package.name}-${project.version}</finalName>
     <pluginManagement>
       <plugins>
         <!-- Apache Plugins -->
@@ -307,6 +318,12 @@ limitations under the License.]]>
           <artifactId>frontend-maven-plugin</artifactId>
           <version>${frontend-maven-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${central-publishing-maven-plugin.version}</version>
+          <extensions>true</extensions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -422,7 +439,7 @@ limitations under the License.]]>
             <configuration>
               <inputSpec>${project.basedir}/api/v5/openapi.yaml</inputSpec>
               <generatorName>java</generatorName>
-              <modelPackage>com.github.guacsec.trustifyda.api.v5</modelPackage>
+              <modelPackage>io.github.guacsec.trustifyda.api.v5</modelPackage>
               <output>${project.build.directory}</output>
               <configOptions>
                 <documentationProvider>none</documentationProvider>
@@ -441,7 +458,7 @@ limitations under the License.]]>
               <addCompileSourceRoot>false</addCompileSourceRoot>
               <addTestCompileSourceRoot>false</addTestCompileSourceRoot>
               <inlineSchemaNameMappings>analysis_200_response=AnalysisResponse</inlineSchemaNameMappings>
-              <schemaMappings>PackageRef=com.github.guacsec.trustifyda.api.PackageRef</schemaMappings>
+              <schemaMappings>PackageRef=io.github.guacsec.trustifyda.api.PackageRef</schemaMappings>
             </configuration>
           </execution>
           <execution>
@@ -582,6 +599,22 @@ limitations under the License.]]>
       <id>release</id>
       <build>
         <plugins>
+          <!-- Disable the default maven-deploy-plugin to avoid conflict -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+            </configuration>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/src/filtered/base/README.md
+++ b/src/filtered/base/README.md
@@ -18,7 +18,7 @@ The packages are published to the GitHub maven repository. Make sure to add it t
 
 ```xml
 <dependency>
-  <groupId>com.github.guacsec</groupId>
+  <groupId>io.github.guacsec</groupId>
   <artifactId>trustify-da-api-model</artifactId>
   <version>${project.version}</version>
 </dependency>

--- a/src/filtered/js-api/package.json
+++ b/src/filtered/js-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@trustify-da/${package.name}",
+  "name": "@trustify-da/${project.artifactId}",
   "version": "${project.version}",
   "description": "Trustify :: Dependency Analytics :: API",
   "author": "Trustify Dependency Analytics Authors",

--- a/src/main/java/io/github/guacsec/trustifyda/api/PackageRef.java
+++ b/src/main/java/io/github/guacsec/trustifyda/api/PackageRef.java
@@ -15,15 +15,16 @@
  * limitations under the License.
  */
 
-package com.github.guacsec.trustifyda.api;
+package io.github.guacsec.trustifyda.api;
 
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.github.guacsec.trustifyda.api.serialization.PackageURLSerializer;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+
+import io.github.guacsec.trustifyda.api.serialization.PackageURLSerializer;
 
 public class PackageRef {
 

--- a/src/main/java/io/github/guacsec/trustifyda/api/serialization/PackageURLSerializer.java
+++ b/src/main/java/io/github/guacsec/trustifyda/api/serialization/PackageURLSerializer.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.github.guacsec.trustifyda.api.serialization;
+package io.github.guacsec.trustifyda.api.serialization;
 
 import java.io.IOException;
 

--- a/src/main/java/io/github/guacsec/trustifyda/api/v5/SeverityUtils.java
+++ b/src/main/java/io/github/guacsec/trustifyda/api/v5/SeverityUtils.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.github.guacsec.trustifyda.api.v5;
+package io.github.guacsec.trustifyda.api.v5;
 
 public class SeverityUtils {
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 module trustifyda.api {
 
-    exports com.github.guacsec.trustifyda.api;
-    exports com.github.guacsec.trustifyda.api.v5;
-    exports com.github.guacsec.trustifyda.api.serialization;
+    exports io.github.guacsec.trustifyda.api;
+    exports io.github.guacsec.trustifyda.api.v5;
+    exports io.github.guacsec.trustifyda.api.serialization;
 
     requires jakarta.annotation;
     requires com.fasterxml.jackson.annotation;
@@ -10,7 +10,7 @@ module trustifyda.api {
     requires com.fasterxml.jackson.databind;
     requires packageurl.java;
 
-    opens com.github.guacsec.trustifyda.api.v5 to com.fasterxml.jackson.databind;
-    opens com.github.guacsec.trustifyda.api to com.fasterxml.jackson.databind;
+    opens io.github.guacsec.trustifyda.api.v5 to com.fasterxml.jackson.databind;
+    opens io.github.guacsec.trustifyda.api to com.fasterxml.jackson.databind;
 
 }

--- a/src/test/java/io/github/guacsec/trustifyda/api/PackageRefTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/api/PackageRefTest.java
@@ -15,12 +15,14 @@
  * limitations under the License.
  */
 
-package com.github.guacsec.trustifyda.api;
+package io.github.guacsec.trustifyda.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+
+import io.github.guacsec.trustifyda.api.PackageRef;
 
 public class PackageRefTest {
 

--- a/src/test/java/io/github/guacsec/trustifyda/api/serialization/PackageURLSerializerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/api/serialization/PackageURLSerializerTest.java
@@ -15,18 +15,19 @@
  * limitations under the License.
  */
 
-package com.github.guacsec.trustifyda.api.serialization;
+package io.github.guacsec.trustifyda.api.serialization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.guacsec.trustifyda.api.PackageRef;
+
+import io.github.guacsec.trustifyda.api.PackageRef;
 
 public class PackageURLSerializerTest {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     void testSerialize() throws JsonProcessingException {


### PR DESCRIPTION
Fix https://github.com/guacsec/trustify-da-api-spec/issues/59

Bumps version to 2.0.0

Renamed packages to `io.github.*`