### PR TITLE
chore(ci): publish npm independently

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,8 +34,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24
-          cache: npm
+          node-version: '20.x'
+          cache: 'none'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Import GPG key for Maven
@@ -45,14 +45,19 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Build and Publish to Maven Central and NPM registry
+      - name: Build and Publish to Maven Central
         run: |
-          mvn -B deploy -Pgpg-sign,publish-npm,publish-maven -Drc.version=${{ github.run_number }} --file pom.xml --settings .github/workflows/maven/settings.xml
+          mvn -B deploy -Pgpg-sign,publish-maven -Drc.version=${{ github.run_number }} --file pom.xml --settings .github/workflows/maven/settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Publish to NPM registry (EA)
+        working-directory: target/js-api
+        run: |
+          npm publish --tag rc --access public --provenance
 
   publish-release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -69,9 +74,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24
-          cache: npm
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'none'
 
       - name: Import GPG key for Maven
         run: |
@@ -123,28 +128,21 @@ jobs:
           echo "NPM package exists: ${{ steps.check_npm.outputs.npm_exists }}"
           echo "Maven artifact exists: ${{ steps.check_maven.outputs.maven_exists }}"
           echo "Will publish: ${{ steps.check_npm.outputs.npm_exists == 'false' || steps.check_maven.outputs.maven_exists == 'false' }}"
-
-      - name: Compute Maven profiles
-        id: compute_profiles
-        run: |
-          PROFILES="gpg-sign,release-npm"
-          if [ "${{ steps.check_npm.outputs.npm_exists }}" = "false" ]; then
-            PROFILES="${PROFILES},publish-npm"
-          fi
-          if [ "${{ steps.check_maven.outputs.maven_exists }}" = "false" ]; then
-            PROFILES="${PROFILES},publish-maven"
-          fi
-          PROFILES="${PROFILES#,}"
-          echo "profiles=-P$PROFILES" >> $GITHUB_OUTPUT
  
-      - name: Build and Publish to Maven Central and NPM registry
-        if: steps.check_npm.outputs.npm_exists == 'false' || steps.check_maven.outputs.maven_exists == 'false'
-        run: mvn -B deploy ${{ steps.compute_profiles.outputs.profiles }} --settings .github/workflows/maven/settings.xml
+      - name: Build and Publish to Maven Central
+        if: steps.check_maven.outputs.maven_exists == 'false'
+        run: mvn -B deploy -Pgpg-sign,publish-maven --settings .github/workflows/maven/settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+
+      - name: Publish to NPM registry
+        if: steps.check_npm.outputs.npm_exists == 'false'
+        working-directory: target/js-api
+        run: |
+          npm publish --access public --provenance
 
       - name: Skip publishing - artifacts already exist
         if: steps.check_npm.outputs.npm_exists == 'true' && steps.check_maven.outputs.maven_exists == 'true'

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
     <!-- NPM Publishing -->
     <rc.version>0</rc.version>
     <npm.version>${version.release}-rc.${rc.version}</npm.version>
-    <npm.tag>--tag rc</npm.tag>
   </properties>
 
   <licenses>

--- a/src/filtered/js-api/package.json
+++ b/src/filtered/js-api/package.json
@@ -24,7 +24,7 @@
     "precompile": "rm -rf dist && npm run lint",
     "compile": "tsc -p tsconfig.json",
     "fix-types": "node fix-types.js",
-    "publish-package": "npm publish ${npm.tag} --access public --provenance"
+    "publish-package": "npm publish --access public --provenance"
   },
   "keywords": [
     "analysis",


### PR DESCRIPTION
Related #86 

It seems the npm package must be published outside of the Maven execution to be able to be compatible with the Trusted Publishers