### PR TITLE
fix: version bump missing update-sources

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -82,13 +82,19 @@ jobs:
         if: github.event_name == 'workflow_run'
         id: releasebranch
         run: |
-          echo "branch=$(cat releasebranch.txt)" >> "$GITHUB_OUTPUT"
+          BRANCH=$(cat releasebranch.txt)
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          # Derive release version and tag from branch (e.g. release/v2.0.5 -> 2.0.5, ref v2.0.5)
+          # Checkout the tag so we publish the release version (2.0.5), not the branch tip (2.0.6-SNAPSHOT)
+          VERSION="${BRANCH#release/v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "ref=v$VERSION" >> "$GITHUB_OUTPUT"
           rm releasebranch.txt
 
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ (github.event_name == 'workflow_run' && steps.releasebranch.outputs.branch) || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_run' && steps.releasebranch.outputs.ref) || github.ref }}
           fetch-depth: 0
 
       - name: Set up Java 17

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,7 @@ jobs:
       - name: Bump to next development version
         run: |
           mvn -B release:update-versions -DgenerateBackupPoms=false
+          mvn -B process-resources
           git add -A
           git commit -m "build(release): bump to next development version"
           git push origin "release/v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix version bump workflow missing update-sources step

- Extract and output release version from branch name

- Checkout correct release tag instead of branch

- Add process-resources step after version update


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Read release branch"] --> B["Extract version from branch name"]
  B --> C["Output version and tag refs"]
  C --> D["Checkout correct release tag"]
  D --> E["Bump to next dev version"]
  E --> F["Process resources"]
  F --> G["Commit and push"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish.yaml</strong><dd><code>Extract version from branch and fix checkout ref</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish.yaml

<ul><li>Extract release version from branch name using parameter expansion<br> <li> Output both version and tag reference as workflow outputs<br> <li> Use extracted tag reference for checkout instead of branch name<br> <li> Add explanatory comments about version derivation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/guacsec/trustify-da-api-spec/pull/103/files#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388ca">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yaml</strong><dd><code>Add process-resources step to release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yaml

<ul><li>Add <code>mvn -B process-resources</code> step after version update<br> <li> Ensures resources are processed during release version bump</ul>


</details>


  </td>
  <td><a href="https://github.com/guacsec/trustify-da-api-spec/pull/103/files#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05ada">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

