### PR TITLE
feat(api): add cves query parameter to v5 analysis endpoints

### DIFF
--- a/api/v5/openapi.yaml
+++ b/api/v5/openapi.yaml
@@ -41,6 +41,13 @@ paths:
           type: boolean
           default: true
         example: true
+      - name: cves
+        in: query
+        description: List of CVEs to include in the report
+        required: false
+        schema:
+          type: string
+        example: CVE-2026-1234,CVE-2026-5678
       requestBody:
         required: true
         description: Dependency graph in SBOM format
@@ -107,6 +114,13 @@ paths:
             type: boolean
             default: true
           example: true
+        - name: cves
+          in: query
+          description: List of CVEs to include in the report
+          required: false
+          schema:
+            type: string
+          example: CVE-2026-1234,CVE-2026-5678
       requestBody:
         required: true
         description: A dictionary of package URLs to dependency graphs in SBOM format

--- a/api/v5/openapi.yaml
+++ b/api/v5/openapi.yaml
@@ -43,7 +43,7 @@ paths:
         example: true
       - name: cves
         in: query
-        description: List of CVEs to include in the report
+        description: Comma-separated list of CVE IDs to filter the report. When provided, only matching CVEs are included. Defaults to all CVEs found.
         required: false
         schema:
           type: string
@@ -116,7 +116,7 @@ paths:
           example: true
         - name: cves
           in: query
-          description: List of CVEs to include in the report
+          description: Comma-separated list of CVE IDs to filter the report. When provided, only matching CVEs are included. Defaults to all CVEs found.
           required: false
           schema:
             type: string


### PR DESCRIPTION
Implements [TC-4318](https://redhat.atlassian.net/browse/TC-4318)

[TC-4318]: https://redhat.atlassian.net/browse/TC-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add support for an optional cves query parameter on v5 analysis endpoints to allow specifying which CVEs to include in reports.

New Features:
- Introduce a cves query parameter on single and batch v5 analysis endpoints to filter reports by a comma-separated list of CVE identifiers.

Documentation:
- Document the new cves query parameter in the v5 OpenAPI specification for analysis endpoints.