### PR TITLE
feat(api): add UNKNOWN value to Severity enum

### DIFF
--- a/api/v5/openapi.yaml
+++ b/api/v5/openapi.yaml
@@ -484,6 +484,7 @@ components:
         - HIGH
         - MEDIUM
         - LOW
+        - UNKNOWN
     Issue:
       type: object
       properties:

--- a/src/test/java/io/github/guacsec/trustifyda/api/v5/SeverityUtilsTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/api/v5/SeverityUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.guacsec.trustifyda.api.v5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class SeverityUtilsTest {
+
+  /** Verifies that fromValue("UNKNOWN") returns Severity.UNKNOWN. */
+  @Test
+  public void testFromValueUnknown() {
+    assertEquals(Severity.UNKNOWN, SeverityUtils.fromValue("UNKNOWN"));
+  }
+
+  /** Verifies that fromValue handles case-insensitive input for UNKNOWN. */
+  @Test
+  public void testFromValueUnknownCaseInsensitive() {
+    assertEquals(Severity.UNKNOWN, SeverityUtils.fromValue("unknown"));
+  }
+
+  /** Verifies that fromValue returns null for null input. */
+  @Test
+  public void testFromValueNull() {
+    assertNull(SeverityUtils.fromValue(null));
+  }
+
+  /** Verifies that fromScore returns only CRITICAL/HIGH/MEDIUM/LOW for all numeric ranges. */
+  @Test
+  public void testFromScoreDoesNotReturnUnknown() {
+    // Given representative scores across all CVSS ranges
+    float[] scores = {0.0f, 1.0f, 3.9f, 4.0f, 6.9f, 7.0f, 8.9f, 9.0f, 10.0f};
+
+    for (float score : scores) {
+      // When calculating severity from a numeric score
+      Severity result = SeverityUtils.fromScore(score);
+
+      // Then UNKNOWN must never be returned
+      assertNotEquals(Severity.UNKNOWN, result,
+          "fromScore(" + score + ") should not return UNKNOWN");
+    }
+  }
+
+  /** Verifies the correct severity boundaries for fromScore. */
+  @Test
+  public void testFromScoreBoundaries() {
+    assertEquals(Severity.LOW, SeverityUtils.fromScore(0.0f));
+    assertEquals(Severity.LOW, SeverityUtils.fromScore(3.9f));
+    assertEquals(Severity.MEDIUM, SeverityUtils.fromScore(4.0f));
+    assertEquals(Severity.MEDIUM, SeverityUtils.fromScore(6.9f));
+    assertEquals(Severity.HIGH, SeverityUtils.fromScore(7.0f));
+    assertEquals(Severity.HIGH, SeverityUtils.fromScore(8.9f));
+    assertEquals(Severity.CRITICAL, SeverityUtils.fromScore(9.0f));
+    assertEquals(Severity.CRITICAL, SeverityUtils.fromScore(10.0f));
+  }
+}


### PR DESCRIPTION
## Summary
- Add `UNKNOWN` to the `Severity` enum in the OpenAPI spec (`api/v5/openapi.yaml`) so vulnerabilities without CVSS scores can be reported with an explicit severity
- Add `SeverityUtilsTest` covering UNKNOWN handling and `fromScore()` boundary verification
- Both Java and TypeScript generated models pick up the new value automatically

Implements [TC-4548](https://redhat.atlassian.net/browse/TC-4548)

## Test plan
- [x] `SeverityUtils.fromValue("UNKNOWN")` returns `Severity.UNKNOWN`
- [x] `SeverityUtils.fromValue("unknown")` returns `Severity.UNKNOWN` (case insensitive)
- [x] `SeverityUtils.fromScore()` returns only CRITICAL/HIGH/MEDIUM/LOW for all numeric ranges
- [x] `mvn compile` generates models without errors
- [x] `mvn test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4548]: https://redhat.atlassian.net/browse/TC-4548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add support for an UNKNOWN severity level in the API and validate its handling in severity utility logic.

New Features:
- Introduce an UNKNOWN value to the Severity enum in the OpenAPI v5 specification to represent vulnerabilities without a CVSS score.

Tests:
- Add SeverityUtilsTest to verify UNKNOWN mapping from string values, null handling, and score-to-severity boundary behavior while ensuring UNKNOWN is never returned from numeric scores.