### PR TITLE
feat(api): add recommendation schemas to v5 OpenAPI spec

### DIFF
--- a/api/v5/openapi.yaml
+++ b/api/v5/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 5.1.0
+  version: 5.2.0
 servers:
   - url: /api/v5
     description: API v5 endpoint
@@ -386,6 +386,10 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/Source'
+        recommendations:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/RecommendationSource'
     ProviderStatus:
       type: object
       properties:
@@ -450,6 +454,8 @@ components:
         recommendations:
           type: integer
           default: 0
+          deprecated: true
+          description: "Deprecated: Use provider-level recommendations map in ProviderReport instead."
         unscanned:
           type: integer
           default: 0
@@ -471,7 +477,8 @@ components:
           items:
             $ref: '#/components/schemas/TransitiveDependencyReport'
         recommendation:
-          description: Trusted Content recommendation that is not related to any security vulnerability
+          description: "Deprecated: Use provider-level recommendations map in ProviderReport instead. Trusted Content recommendation that is not related to any security vulnerability."
+          deprecated: true
           allOf:
             - $ref: '#/components/schemas/PackageRef'
         highestVulnerability:
@@ -571,6 +578,38 @@ components:
           $ref: '#/components/schemas/PackageRef'
         reason:
           type: string
+    RecommendationSource:
+      type: object
+      description: Recommendation data from a specific recommendation source
+      properties:
+        status:
+          type: string
+          description: Health status of the recommendation source
+        summary:
+          $ref: '#/components/schemas/RecommendationSummary'
+        dependencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecommendationReport'
+    RecommendationSummary:
+      type: object
+      description: Summary of recommendations from a recommendation source
+      properties:
+        total:
+          type: integer
+          default: 0
+    RecommendationReport:
+      type: object
+      description: A recommendation mapping a dependency to its recommended alternative
+      properties:
+        ref:
+          description: The original dependency being analyzed
+          allOf:
+            - $ref: '#/components/schemas/PackageRef'
+        recommendation:
+          description: The recommended alternative package
+          allOf:
+            - $ref: '#/components/schemas/PackageRef'
     LicensesRequest:
       type: object
       description: List of package URLs (purls) to fetch license information for


### PR DESCRIPTION
## Summary

- Add `RecommendationSource`, `RecommendationReport`, and `RecommendationSummary` schemas to support provider-level recommendations from multiple sources (trusted-content, hardened-images, trusted-libraries)
- Add `recommendations` map to `ProviderReport` using `additionalProperties`, mirroring the existing `sources` pattern
- Deprecate `DependencyReport.recommendation` and `SourceSummary.recommendations` fields with deprecation notes
- Bump spec version from 5.1.0 to 5.2.0

Implements [TC-4691](https://redhat.atlassian.net/browse/TC-4691)

## Test plan

- [x] `npx @redocly/cli lint api/v5/openapi.yaml` passes with no errors
- [x] `mvn verify` succeeds (Java and TypeScript model generation)

[TC-4691]: https://redhat.atlassian.net/browse/TC-4691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add provider-level recommendation support to the v5 OpenAPI spec and deprecate legacy recommendation fields.

New Features:
- Introduce provider-level recommendations map on ProviderReport keyed by recommendation sources.
- Add RecommendationSource, RecommendationSummary, and RecommendationReport schemas to model recommendations from multiple sources.

Enhancements:
- Deprecate recommendation-related fields on DependencyReport and SourceSummary in favor of provider-level recommendations.
- Bump OpenAPI spec version from 5.1.0 to 5.2.0 to reflect the new recommendation model.