### PR TITLE
feat(api): add unknown severity field and enum value

### DIFF
--- a/api/v5/openapi.yaml
+++ b/api/v5/openapi.yaml
@@ -448,6 +448,9 @@ components:
         low:
           type: integer
           default: 0
+        unknown:
+          type: integer
+          default: 0
         remediations:
           type: integer
           default: 0
@@ -491,6 +494,7 @@ components:
         - HIGH
         - MEDIUM
         - LOW
+        - UNKNOWN
     Issue:
       type: object
       properties:

--- a/src/main/java/io/github/guacsec/trustifyda/api/v5/SeverityUtils.java
+++ b/src/main/java/io/github/guacsec/trustifyda/api/v5/SeverityUtils.java
@@ -27,7 +27,10 @@ public class SeverityUtils {
   }
 
   // From: https://nvd.nist.gov/vuln-metrics/cvss
-  public static Severity fromScore(float score) {
+  public static Severity fromScore(Float score) {
+    if (score == null) {
+      return Severity.UNKNOWN;
+    }
     if (score < 4) {
       return Severity.LOW;
     }

--- a/src/test/java/io/github/guacsec/trustifyda/api/v5/SeverityUtilsTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/api/v5/SeverityUtilsTest.java
@@ -48,14 +48,19 @@ class SeverityUtilsTest {
   }
 
   @Test
+  void fromScoreReturnsUnknownForNullInput() {
+    assertEquals(Severity.UNKNOWN, SeverityUtils.fromScore(null));
+  }
+
+  @Test
   void fromScoreMapsCvssRanges() {
-    assertEquals(Severity.LOW, SeverityUtils.fromScore(0));
+    assertEquals(Severity.LOW, SeverityUtils.fromScore(0f));
     assertEquals(Severity.LOW, SeverityUtils.fromScore(3.9f));
-    assertEquals(Severity.MEDIUM, SeverityUtils.fromScore(4));
+    assertEquals(Severity.MEDIUM, SeverityUtils.fromScore(4f));
     assertEquals(Severity.MEDIUM, SeverityUtils.fromScore(6.9f));
-    assertEquals(Severity.HIGH, SeverityUtils.fromScore(7));
+    assertEquals(Severity.HIGH, SeverityUtils.fromScore(7f));
     assertEquals(Severity.HIGH, SeverityUtils.fromScore(8.9f));
-    assertEquals(Severity.CRITICAL, SeverityUtils.fromScore(9));
-    assertEquals(Severity.CRITICAL, SeverityUtils.fromScore(10));
+    assertEquals(Severity.CRITICAL, SeverityUtils.fromScore(9f));
+    assertEquals(Severity.CRITICAL, SeverityUtils.fromScore(10f));
   }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/api/v5/SeverityUtilsTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/api/v5/SeverityUtilsTest.java
@@ -37,8 +37,14 @@ class SeverityUtilsTest {
   }
 
   @Test
-  void fromValueRejectsUnknownSeverity() {
-    assertThrows(IllegalArgumentException.class, () -> SeverityUtils.fromValue("unknown"));
+  void fromValueParsesUnknownSeverity() {
+    assertEquals(Severity.UNKNOWN, SeverityUtils.fromValue("unknown"));
+    assertEquals(Severity.UNKNOWN, SeverityUtils.fromValue("UNKNOWN"));
+  }
+
+  @Test
+  void fromValueRejectsInvalidSeverity() {
+    assertThrows(IllegalArgumentException.class, () -> SeverityUtils.fromValue("invalid"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Add `unknown` integer property (default `0`) to the `SourceSummary` schema in the v5 OpenAPI spec, positioned after `low` and before `remediations`, to count vulnerabilities with no CVSS score or severity classification
- Add `UNKNOWN` value to the `Severity` enum after `LOW`
- Update `SeverityUtilsTest` to validate `UNKNOWN` as a valid severity value instead of rejecting it

## Test plan

- [x] OpenAPI spec passes `npx @redocly/cli lint api/v5/openapi.yaml` validation
- [x] `mvn package` succeeds with all tests passing (25 tests)
- [x] Generated `SourceSummary.java` has `getUnknown()`/`setUnknown()` methods
- [x] Generated `SourceSummary.ts` has `unknown?: number` field
- [x] Generated `Severity.java` has `UNKNOWN` enum constant
- [x] Generated `Severity.ts` has `Unknown = 'UNKNOWN'` entry

Implements [TC-4723](https://redhat.atlassian.net/browse/TC-4723)

[TC-4723]: https://redhat.atlassian.net/browse/TC-4723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add support for an UNKNOWN severity level and an unknown vulnerability count in the v5 API schema and utilities.

New Features:
- Expose an unknown integer field on SourceSummary in the v5 OpenAPI schema to count vulnerabilities without a known severity.
- Introduce an UNKNOWN value in the Severity enum to represent vulnerabilities with unspecified severity.

Tests:
- Update SeverityUtils tests to treat UNKNOWN as a valid severity and to ensure invalid severities still throw errors.