### PR TITLE
feat: extend Remediation model for Trustify v3 version ranges

### DIFF
--- a/api/v5/openapi.yaml
+++ b/api/v5/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 5.2.0
+  version: 5.3.0
 servers:
   - url: /api/v5
     description: API v5 endpoint
@@ -539,6 +539,16 @@ components:
           type: array
           items:
             type: string
+        remediations:
+          type: array
+          description: Detailed remediation information from vulnerability advisories
+          items:
+            $ref: '#/components/schemas/RemediationInfo'
+        versionRanges:
+          type: array
+          description: Affected version ranges from vulnerability advisories
+          items:
+            $ref: '#/components/schemas/VersionRange'
         trustedContent:
           type: object
           properties:
@@ -548,6 +558,47 @@ components:
               type: string
             justification:
               type: string
+    RemediationCategory:
+      type: string
+      description: Category of a remediation action
+      enum:
+        - VENDOR_FIX
+        - WORKAROUND
+        - MITIGATION
+        - NO_FIX_PLANNED
+        - NONE_AVAILABLE
+        - WILL_NOT_FIX
+    RemediationInfo:
+      type: object
+      description: Detailed remediation information from a vulnerability advisory
+      properties:
+        category:
+          $ref: '#/components/schemas/RemediationCategory'
+        details:
+          type: string
+          description: Human-readable remediation details
+        url:
+          type: string
+          description: URL with more information about the remediation
+    VersionRange:
+      type: object
+      description: Affected version range from a vulnerability advisory. Fields present depend on the range type - Full (all fields), Left (scheme and low bound), Right (scheme and high bound), or Unbounded (empty).
+      properties:
+        versionSchemeId:
+          type: string
+          description: Version scheme identifier (e.g. semver, rpm, generic)
+        lowVersion:
+          type: string
+          description: Lower bound version
+        lowInclusive:
+          type: boolean
+          description: Whether the lower bound is inclusive
+        highVersion:
+          type: string
+          description: Upper bound version
+        highInclusive:
+          type: boolean
+          description: Whether the upper bound is inclusive
     CvssVector:
       type: object
       properties:


### PR DESCRIPTION
## Summary

- Add `VersionRange` schema to represent Trustify v3's structured version range data (Full, Left, Right, Unbounded variants)
- Add `RemediationCategory` enum (VENDOR_FIX, WORKAROUND, MITIGATION, NO_FIX_PLANNED, NONE_AVAILABLE, WILL_NOT_FIX)
- Add `RemediationInfo` schema with category, details, and URL fields
- Extend `Remediation` with optional `remediations` and `versionRanges` arrays
- Preserve existing `fixedIn` field for backward compatibility
- Bump API model version from 5.2.0 to 5.3.0

## Jira

[TC-4521](https://redhat.atlassian.net/browse/TC-4521)

## Test plan

- [x] OpenAPI spec validates with Redocly CLI
- [x] Generated Java model classes compile (`mvn clean verify`)
- [x] Generated JavaScript/TypeScript model classes build
- [x] Existing `fixedIn` field preserved in generated Remediation class
- [x] New `RemediationCategory`, `RemediationInfo`, `VersionRange` classes generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4521]: https://redhat.atlassian.net/browse/TC-4521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Extend the remediation schema and versioning to support structured remediation and version range data from vulnerability advisories.

New Features:
- Add detailed remediation entries and affected version ranges to the Remediation schema to capture advisory metadata.
- Introduce RemediationCategory and RemediationInfo schemas for categorizing and describing remediation actions.
- Introduce a VersionRange schema to represent structured affected version range information.

Build:
- Bump API model version from 5.2.0 to 5.3.0 in the OpenAPI specification.