### PR TITLE
feat: add AdvisoryInfo schema to RemediationInfo

### DIFF
--- a/api/v5/openapi.yaml
+++ b/api/v5/openapi.yaml
@@ -580,6 +580,23 @@ components:
         url:
           type: string
           description: URL with more information about the remediation
+        advisory:
+          $ref: '#/components/schemas/AdvisoryInfo'
+    AdvisoryInfo:
+      type: object
+      description: Source advisory attribution for a remediation
+      properties:
+        id:
+          type: string
+          description: Advisory identifier (e.g. RHSA-2024:1234, GHSA-xxxx-xxxx-xxxx)
+        title:
+          type: string
+          description: Advisory title or summary
+        url:
+          type: string
+          description: URL to the full advisory document
+      required:
+        - id
     VersionRange:
       type: object
       description: Affected version range from a vulnerability advisory. Fields present depend on the range type - Full (all fields), Left (scheme and low bound), Right (scheme and high bound), or Unbounded (empty).

--- a/api/v5/openapi.yaml
+++ b/api/v5/openapi.yaml
@@ -579,6 +579,7 @@ components:
           description: Human-readable remediation details
         url:
           type: string
+          format: uri
           description: URL with more information about the remediation
         advisory:
           $ref: '#/components/schemas/AdvisoryInfo'
@@ -594,6 +595,7 @@ components:
           description: Advisory title or summary
         url:
           type: string
+          format: uri
           description: URL to the full advisory document
       required:
         - id


### PR DESCRIPTION
## Summary

- Add `AdvisoryInfo` schema (`id` required, `title` optional, `url` optional) to the OpenAPI v5 spec
- Add optional `advisory` property to `RemediationInfo` referencing `AdvisoryInfo`
- Enables clients and IDE extensions to display advisory attribution for each remediation

Ref: [TC-5018](https://redhat.atlassian.net/browse/TC-5018)

## Test plan

- [x] `mvn validate` passes
- [x] `mvn generate-sources` produces `AdvisoryInfo` in both Java and TypeScript targets
- [x] Generated `RemediationInfo` includes `advisory` field in both languages

[TC-5018]: https://redhat.atlassian.net/browse/TC-5018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add advisory metadata support to remediation information in the OpenAPI v5 specification.

New Features:
- Introduce an AdvisoryInfo schema with required identifier and optional title and URL fields.
- Allow RemediationInfo objects to include optional advisory information referencing AdvisoryInfo.